### PR TITLE
update and fix color mode, markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # timechain-web
 timechain academy website
 
-just bitkarrot messing around with nuxt3, trying to make it look pretty
+## Commands
 
-Todo list: 
+`yarn install`  installs dependencies
+`yarn dev -o`   starts local dev server at `localhost:3000`
+
+
+## Todo list: 
 - use tailnuxt template [done]
 - apply styles, logos, images [done]
-- add Nuxt 3 Content for markdown ability [done] [but use timechain-docs repo instead]
+- add Nuxt 3 Content for markdown ability [done] [see timechain-docs repo]
 - organize content and guides [done] [see timechain-docs]
-- add meetings/events/bookings calendar w/static data backend [todo]
-- integrate cal.com and/or lightning payments for teaching sessions [todo]
+- add events calendar & 1on1 ssr w/static data backend [todo]
+- fix up connect page [todo]
+- integrate cal.com and/or btc/ln payments for teaching sessions [todo]
+
+### CSS styling
+
+- tailwindcss
+- @tailwindcss/typography
+- @tailwindcss/forms
+- hyperUI front page layout
+- Daisy UI for components

--- a/app.vue
+++ b/app.vue
@@ -1,4 +1,6 @@
 <template>
+       <body class="bg-white dark:bg-slate-900"> 
       <NuxtPage/>
+      </body>
   </template>
   

--- a/assets/base.css
+++ b/assets/base.css
@@ -4,12 +4,12 @@
 @tailwind utilities;
 
 @layer components {
-  .btn {
-    @apply inline-flex items-center justify-center rounded-md border border-transparent font-medium text-center text-base leading-snug transition py-3 px-6 shadow-md ease-in duration-100 focus:ring-blue-500 focus:ring-offset-blue-200 focus:ring-2 focus:ring-offset-2;
-  }
-  .btn-ghost {
-		@apply border-none shadow-none text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white;
+	.btn {
+		@apply inline-flex items-center justify-center rounded-md border border-transparent font-medium text-center text-base leading-snug transition py-3 px-6 shadow-md ease-in duration-100 focus:ring-blue-500 focus:ring-offset-blue-200 focus:ring-2 focus:ring-offset-2;
 	}
+	.btn-ghost {
+			@apply border-none shadow-none text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white;
+		}
 	.btn-primary {
 		@apply font-semibold bg-primary-600 text-white border-primary-600 hover:bg-primary-800 hover:border-primary-800 hover:text-white dark:text-white dark:bg-primary-700 dark:border-primary-700 dark:hover:border-primary-900 dark:hover:bg-primary-900;
 	}

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,7 +1,7 @@
 <template>
-<footer class="footer items-center p-4 bg-neutral text-neutral-content">
+<footer class="bg-white dark:bg-slate-900 footer items-center p-4 bg-neutral text-neutral-content">
   <div class="items-center grid-flow-col">
-    <p>Copyright © 2022 - All right reserved</p>
+    <p class="text-slate-900 dark:text-white">Copyright © 2022 - All right reserved</p>
   </div> 
 
 </footer>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,14 +1,20 @@
 <template>
   <header
-    class="sticky top-0 z-40 flex-none mx-auto w-full  bg-white  md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900/90 md:backdrop-blur-sm border-b dark:border-b-0">
+    class="sticky top-0 z-40 flex-none mx-auto w-full bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 md:backdrop-blur-sm border-b dark:border-b-0">
     <div class="py-3 px-3 mx-auto w-full md:flex md:justify-between max-w-6xl md:px-4">
       <div class="flex justify-between">
         <a class="flex items-center" href="/">
           <Logo />
         </a>
-        <div class="flex items-center md:hidden"></div>
+        <div class="flex items-center md:hidden">
+          <!-- what goes here? -->
+        </div>
       </div>
-      <nav class="items-center w-full md:w-auto hidden md:flex  h-screen md:h-auto" id="menu">
+      <nav
+			class="items-center w-full md:w-auto hidden md:flex text-gray-600 dark:text-slate-200 h-[calc(100vh-100px)] md:h-auto overflow-y-auto md:overflow-visible"
+			aria-label="Main navigation"
+		>
+      <!-- <nav class="items-center w-full md:w-auto hidden md:flex  h-screen md:h-auto" id="menu"> -->
         <ul class="flex flex-col pt-8 md:pt-0 md:flex-row md:self-center md:w-auto collapsed text-xl md:text-base">
           <li>
             <a class="font-medium hover:text-gray-400 dark:hover:text-white px-4 py-3 flex items-center transition duration-150 ease-in-out"
@@ -60,6 +66,7 @@
 
 
 <script setup>
+
 const colorMode = useColorMode()
 console.log("initial color mode: ", colorMode.preference)
 function toggleDarkMode() {
@@ -76,7 +83,7 @@ function toggleDarkMode() {
 
 
 <style>
-
+/* 
     body {
       background-color: #fff;
       color: rgba(0, 0, 0, 0.8);
@@ -121,6 +128,7 @@ function toggleDarkMode() {
       .md\:bg-white\/90 {
         background-color: rgb(255 255 255 / 0.9);
       }
-    }
+    } 
+*/
 
 </style> 

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -1,5 +1,6 @@
 <template> 
-  <section class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
+<section>
+<!-- <section class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0"> -->
     <div class="max-w-6xl mx-auto px-4 sm:px-6">
       <div class="py-12 md:py-20">
         <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -1,9 +1,9 @@
 <template> 
-  <section>
+  <section class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
     <div class="max-w-6xl mx-auto px-4 sm:px-6">
       <div class="py-12 md:py-20">
         <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
-          <h1 class="text-5xl md:text-6xl font-bold leading-tighter tracking-tighter mb-6 font-heading">
+          <h1 class="text-5xl md:text-6xl font-bold dark:text-white leading-tighter tracking-tighter mb-6 font-heading">
             
             ₿itcoin and ⚡️ Lightning
             Turbo Charged Space

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -51,8 +51,9 @@
 <style>
 /* change .dark to be .dark-mode so that it can work with @nuxtjs/color-mode  */
 
-.dark-mode .dark\:hover\:bg-gray-800:hover {
+/* .dark-mode .dark\:hover\:bg-gray-800:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-} 
+}  */
+
 </style>

--- a/components/Instructor.vue
+++ b/components/Instructor.vue
@@ -18,7 +18,7 @@
                             class="absolute inset-0"></span>Brent Garner
                         </a>
                 </div>
-                <div class="mt-0.5 text-black">Developer</div>
+                <div class="mt-0.5 text-black dark:text-white">Developer</div>
             </div>
             <div class="text-sky-500 dark:text-sky-400">
                <p> <a href="/connect" class="font-bold">Book a session</a></p>

--- a/components/Logo.vue
+++ b/components/Logo.vue
@@ -1,6 +1,6 @@
 <template>
       <nuxt-img src="/apple-touch-icon.png" width="50" height="50"/>
-      <span className="self-center ml-2 text-2xl font-extrabold whitespace-nowrap ">
+      <span class="self-center hover:text-gray-400 dark:text-white ml-2 text-2xl font-extrabold whitespace-nowrap ">
           Timechain Academy
     </span>
 </template>

--- a/components/Splash.vue
+++ b/components/Splash.vue
@@ -1,5 +1,6 @@
 <template>
-    <section class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
+<section>
+<!-- <section class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0"> -->
         <div class="mx-auto max-w-screen-xl px-4 py-16 sm:px-6 lg:px-8">
             <div class="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-16">
                 <div class="relative h-64 overflow-hidden rounded-lg sm:h-80 lg:order-last lg:h-full">

--- a/components/Splash.vue
+++ b/components/Splash.vue
@@ -1,5 +1,5 @@
 <template>
-    <section>
+    <section class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
         <div class="mx-auto max-w-screen-xl px-4 py-16 sm:px-6 lg:px-8">
             <div class="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-16">
                 <div class="relative h-64 overflow-hidden rounded-lg sm:h-80 lg:order-last lg:h-full">
@@ -9,9 +9,9 @@
                 </div>
 
                 <div class="lg:py-24">
-                    <h2 class="text-3xl font-bold sm:text-4xl">Expand your mind</h2>
+                    <h2 class="text-3xl font-bold dark:text-white sm:text-4xl">Expand your mind</h2>
 
-                    <p class="mt-4 text-gray-600">
+                    <p class="mt-4 text-gray-600 dark:text-slate-400">
                         Lorem ipsum dolor, sit amet consectetur adipisicing elit. Aut qui hic
                         atque tenetur quis eius quos ea neque sunt, accusantium soluta minus
                         veniam tempora deserunt? Molestiae eius quidem quam repellat.

--- a/content/codeblock.md
+++ b/content/codeblock.md
@@ -16,3 +16,17 @@ server.listen(port, hostname, () => {
 });
 
 ```
+# Header 1
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex ut quo possimus adipisci distinctio alias voluptatum blanditiis laudantium. Lorem ipsum dolor sit amet consectetur adipisicing elit. 
+
+## Header 2
+
+- list item 1
+- list item 2 
+- list item 3
+
+### Header 3
+
+Ex ut quo possimus adipisci distinctio alias voluptatum blanditiis laudantium.
+Ex ut quo possimus adipisci distinctio alias voluptatum blanditiis laudantium.

--- a/content/index.md
+++ b/content/index.md
@@ -6,7 +6,7 @@ I am using a :github-button in the middle of a paragraph.
 
 # Hello Content in top level directory
 
-this is a page in markdown using the content module this is a page in markdown using the content modulethis is a page in markdown using the content modulethis is a page in markdown using the content modulethis is a page in markdown using the content modulethis is a page in markdown using the content modulethis is a page in markdown using the content module
+this is a page in markdown using the content module. Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex ut quo possimus adipisci distinctio alias voluptatum blanditiis laudantium. Lorem ipsum dolor sit amet consectetur adipisicing elit. this is a page in markdown using the content module.
 
 # Header One
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
       <slot />
     </div>
   </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,7 @@
 <template>
-    <div class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
+    <!-- redundant, fix this-->
+    <!-- <div class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0"> -->
       <slot />
-    </div>
-  </template>
+    <!-- </div> -->
+</template>
   

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,8 +23,9 @@ export default defineNuxtConfig({
             globalName: '__NUXT_COLOR_MODE__',    
             componentName: 'ColorScheme',    
             classPrefix: '',   
-            classSuffix: '-mode',    
-            storageKey: 'nuxt-color-mode' 
+//            classSuffix: '-mode',    
+            classSuffix:'',
+           storageKey: 'nuxt-color-mode' 
       }, 
       image: {    // The screen sizes predefined by `@nuxt/image`:   
              screens: {      

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,9 @@ export default defineNuxtConfig({
       ],
       content: { 
             highlight: {
-                   theme: 'one-dark-pro'
+                  theme: {
+                        default: 'one-dark-pro', 
+                  },
                },
             documentDriven: true
             // https://content.nuxtjs.org/api/configuration

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@nuxt/ui": "^0.3.3",
-    "@tailwindcss/forms": "^0.5.3"
+    "@tailwindcss/forms": "^0.5.3",
+    "@tailwindcss/typography": "^0.5.8"
   }
 }

--- a/pages/1on1.vue
+++ b/pages/1on1.vue
@@ -5,11 +5,11 @@
                     This page needs to read content dynamically from a component
      -->
             <div class="text-center py-6"> 
-                <h1 class="text-5xl md:text-6xl font-bold leading-tighter tracking-tighter mb-6 font-heading">         
+                <h1 class="text-5xl md:text-6xl dark:text-white  font-bold leading-tighter tracking-tighter mb-6 font-heading">         
                 1 on 1 sessions
             </h1> 
 
-                <p class="text-lg font-medium ">
+                <p class="text-lg font-medium dark:text-white">
                             Book a 1 on 1 session with a timechain academy instructor here. 
             </p>
             </div>

--- a/pages/blog.vue
+++ b/pages/blog.vue
@@ -1,25 +1,24 @@
 <template>
 	<NuxtLayout :name="layout">
     	<Header />
-		<main>
+		<main class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
 		<div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
-		<h1>
-			Blog
-        </h1>
-		<h2 class="py-5 text-red-500">markdown isn't styling in dark mode, need fix </h2>
+			<h1 class="py-5 mx-auto text-center text-5xl md:text-6xl text-gray-900 dark:text-white font-bold mb-6">
+				 Blog 
+			</h1>
 			<div class="px-5 mx-auto text-left">
 					<article>
 						<ContentDoc path="/" class="prose dark:prose-invert" />
 					</article>
 			</div>
 		<div class="px-5 mx-auto text-left">
-			<div class="">
+			<div class="text-gray-900 dark:text-white">
 				This code block below is generated in markdown
 				and added here by a `ContentDoc` tag. The section below is text in markdown.
 				CSS styles on this page are scoped to the blog.vue page.
 			</div>
 
-			<p class="py-5 text-left"><b>Node.js sample code, formatted with color from Markdown source</b>
+			<p class="py-5 text-gray-900 dark:text-white text-left"><b>Node.js sample code, formatted with color from Markdown source</b>
 			</p>
 
 			<ContentDoc path="/codeblock" class="prose dark:prose-invert text-left" />
@@ -38,17 +37,26 @@
 <style scoped>
 /* change .dark to be .dark-mode so that it can work with @nuxtjs/color-mode  */
 
-@tailwind base; 
 
- @layer base {
+/* .dark body {
+      background-color: rgb(15 23 42);
+      color: #ebf4f1;
+    }  */
+
+/* @tailwind base; 
+
+@layer base {
+*/
 		/* p {
 			@apply text-xl text-gray-500 mb-6;
 		} */
+/* 		
 		h1 {
 			@apply text-5xl md:text-6xl font-bold mb-6;
 		}
 		h2 {
 			@apply text-3xl md:text-4xl font-bold mb-4;
 		}
-	} 
+	}   */
+
 </style>

--- a/pages/blog.vue
+++ b/pages/blog.vue
@@ -6,26 +6,27 @@
 		<h1>
 			Blog
         </h1>
-
-		<div class="px-5 mx-auto">
-			<div class="text-left">
+		<h2 class="py-5">markdown isn't styling in dark mode, need fix </h2>
+			<div class="px-5 mx-auto text-left">
+					<article>
+						<ContentDoc path="/" class="prose dark:prose-invert" />
+					</article>
+			</div>
+		<div class="px-5 mx-auto text-left">
+			<div class="">
 				This code block below is generated in markdown
 				and added here by a `ContentDoc` tag. The section below is text in markdown.
 				CSS styles on this page are scoped to the blog.vue page.
 			</div>
 
-			<p class="py-5 text-left"><b>Node.js sample code, formatted with color.</b></p>
+			<p class="py-5 text-left"><b>Node.js sample code, formatted with color from Markdown source</b>
+			</p>
 
-			<div class="container">
-			<ContentDoc path="/codeblock" class="prose text-left" />
-	        </div>
+			<ContentDoc path="/codeblock" class="prose dark:prose-invert text-left" />
 		</div>
-			<div class="px-5 mx-auto text-left">
-				<h2>Not sure why the markdown isn't rendering properly here, need to fix </h2>
-				<ContentDoc path="/" class="prose text-left" />
-			</div>
-    </div>
-	</main>
+	</div>
+
+</main>
 	</NuxtLayout>
 </template>
 
@@ -35,25 +36,19 @@
 
 
 <style scoped>
+/* change .dark to be .dark-mode so that it can work with @nuxtjs/color-mode  */
+
 @tailwind base; 
 
-@layer base {
-		p {
+ @layer base {
+		/* p {
 			@apply text-xl text-gray-500 mb-6;
-		}
+		} */
 		h1 {
-			@apply text-5xl md:text-6xl font-bold leading-tight tracking-tighter mb-6;
+			@apply text-5xl md:text-6xl font-bold mb-6;
 		}
 		h2 {
-			@apply text-4xl md:text-5xl font-bold leading-tight tracking-tighter mb-4;
+			@apply text-3xl md:text-4xl font-bold mb-4;
 		}
-	}
-	.container {  
-		background: #1e1e1e;  
-		padding: 2rem 2rem;
-		position: relative;  
-		margin-top: 1rem;  
-		margin-bottom: 1rem;  
-		overflow: hidden;  
-		border-radius: 0.3rem;}
+	} 
 </style>

--- a/pages/blog.vue
+++ b/pages/blog.vue
@@ -6,7 +6,7 @@
 		<h1>
 			Blog
         </h1>
-		<h2 class="py-5">markdown isn't styling in dark mode, need fix </h2>
+		<h2 class="py-5 text-red-500">markdown isn't styling in dark mode, need fix </h2>
 			<div class="px-5 mx-auto text-left">
 					<article>
 						<ContentDoc path="/" class="prose dark:prose-invert" />

--- a/pages/connect.vue
+++ b/pages/connect.vue
@@ -1,47 +1,30 @@
 <template>
-    <!--
-                    This page needs to read content dynamically from a component
-     -->
-     <NuxtLayout :name="layout">
-        <Header />
+    <NuxtLayout :name="layout">
+      <Header />
+      <!--
+                      This page needs to read content dynamically from a component
+       -->
+      <main class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
         <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
-            <h1 class="text-5xl md:text-6xl font-bold leading-tighter tracking-tighter mb-6 font-heading">
-                Connect
-            </h1>
-            <h3 class="font-bold">
-                Examples of things that might go here:
-            </h3>
-            <div class="py-5"> 
-                <p>
-                <ul>
-                    <li>
-                        - A Contact Form
-                    </li>
-                    <li>
-                        - Link to Discord
-                    </li>
-                    <li>
-                        - Register for courses
-                    </li>
-                    <li>
-                        - Book 1 on 1 sessions
-                    </li>
-                </ul>
-                </p>
-                <p class="py-6"> FOSS Sites where we can get tailwind components from, with no license, and will
-                    blend in with this site: </p>
-                    <li >
-                        <a href="https://www.hyperui.dev/">https://www.hyperui.dev/</a>
-                    </li>
-                    <li><a href="https://tailwindcss-forms.vercel.app/">https://tailwindcss-forms.vercel.app/</a>
-                    </li>
+          <h1 class="text-5xl md:text-6xl dark:text-white font-bold leading-tighter tracking-tighter mb-6 font-heading">
+            Connect
+          </h1>
+          <div class="p-8 sm:p-16 lg:p-24">
+                    <h2 class="text-2xl font-bold sm:text-3xl text-black dark:text-white">
+                      Join our Discord
+                    </h2>
+                    <a href="#"
+                      class="mt-8 inline-block rounded border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500">
+                      Get in Touch
+                    </a>
+                  </div>
 
 
-            </div>
         </div>
+      </main>
     </NuxtLayout>
-</template>
-
-<script setup> 
+  </template>
+  
+  <script setup>
   const layout = "default";
-</script>
+  </script>

--- a/pages/courses.vue
+++ b/pages/courses.vue
@@ -1,15 +1,16 @@
 <template>
     <NuxtLayout :name="layout">
     	<Header />
+        <main class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
         <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
-            <h1 class="text-5xl md:text-6xl font-bold leading-tighter tracking-tighter mb-6 font-heading">
+            <h1 class="text-5xl dark:text-white md:text-6xl font-bold leading-tighter tracking-tighter mb-6 font-heading">
                 Courses
             </h1>
-            <p>
+            <p class="dark:text-white">
                 Description about the course setup here. 
             </p>
             <div>
-                <table class="table-auto dark:bg-slate-700">
+                <table class="table-auto bg-white dark:bg-slate-700 dark:text-white ">
                     <thead>
                         <tr>
                             <th class="px-4 py-2">Title</th>
@@ -38,6 +39,7 @@
                 </table>
             </div>
         </div>
+        </main>
         </NuxtLayout>
 </template>
 

--- a/pages/courses.vue
+++ b/pages/courses.vue
@@ -1,16 +1,15 @@
 <template>
     <NuxtLayout :name="layout">
     	<Header />
-        <main class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
         <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
-            <h1 class="text-5xl dark:text-white md:text-6xl font-bold leading-tighter tracking-tighter mb-6 font-heading">
+            <h1 class="py-6 text-5xl dark:text-white md:text-6xl font-bold leading-tighter tracking-tighter mb-6 font-heading">
                 Courses
             </h1>
-            <p class="dark:text-white">
+            <p class="py-6 text-gray-900 dark:text-white">
                 Description about the course setup here. 
             </p>
-            <div>
-                <table class="table-auto bg-white dark:bg-slate-700 dark:text-white ">
+            <div class="py-6">
+                <table class="table-auto bg-white dark:bg-slate-900 dark:text-white ">
                     <thead>
                         <tr>
                             <th class="px-4 py-2">Title</th>
@@ -39,7 +38,6 @@
                 </table>
             </div>
         </div>
-        </main>
         </NuxtLayout>
 </template>
 

--- a/pages/events.vue
+++ b/pages/events.vue
@@ -1,58 +1,48 @@
 <template>
-    <NuxtLayout :name="layout">
+  <NuxtLayout :name="layout">
     <Header />
-     <!--
+    <!--
                     This page needs to read content dynamically from a component
      -->
-     <main class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
-            <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
-                <h1 class="text-5xl md:text-6xl dark:text-white font-bold leading-tighter tracking-tighter mb-6 font-heading">         
-                Events
-                </h1> 
-                <section>
-  <div class="mx-auto max-w-screen-2xl px-4 py-16 sm:px-6 lg:px-8">
-    <div class="grid grid-cols-1 lg:h-screen lg:grid-cols-2">
-      <div class="relative z-10 lg:py-16">
-        <div class="relative h-64 sm:h-80 lg:h-full">
-          <nuxt-img
-            alt="Events"
-            src="/sample-imgs/sd3.png"
-            class="absolute inset-0 h-full w-full object-cover"
-          />
-        </div>
-      </div>
-      <div class="relative flex items-center bg-gray-100">
-        <span
-          class="hidden lg:absolute lg:inset-y-0 lg:-left-16 lg:block lg:w-16 lg:bg-gray-100"
-        ></span>
+    <main class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
+      <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
+        <h1 class="text-5xl md:text-6xl dark:text-white font-bold leading-tighter tracking-tighter mb-6 font-heading">
+          Events
+        </h1>
+        <section>
+          <div class="mx-auto max-w-screen-2xl px-4 py-16 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 lg:h-screen lg:grid-cols-2">
+              <div class="relative z-10 lg:py-16">
+                <div class="relative h-64 sm:h-80 lg:h-full">
+                  <nuxt-img alt="Events" src="/sample-imgs/sd3.png"
+                    class="absolute inset-0 h-full w-full object-cover" />
+                </div>
+              </div>
+              <div class="relative flex items-center bg-gray-100">
+                <span class="hidden lg:absolute lg:inset-y-0 lg:-left-16 lg:block lg:w-16 lg:bg-gray-100"></span>
 
-        <div class="p-8 sm:p-16 lg:p-24">
-          <h2 class="text-2xl font-bold sm:text-3xl text-black">
-           Join our Awesome Events.
-          </h2>
+                <div class="p-8 sm:p-16 lg:p-24">
+                  <h2 class="text-2xl font-bold sm:text-3xl text-black">
+                    Join our Awesome Events.
+                  </h2>
 
-          <p class="mt-4 text-gray-600">
-            Event Calendar below. 
-          </p>
-          <a
-            href="#"
-            class="mt-8 inline-block rounded border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500"
-          >
-            Get in Touch
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-                
+                  <p class="mt-4 text-gray-600">
+                    Event Calendar below.
+                  </p>
+                  <a href="#"
+                    class="mt-8 inline-block rounded border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500">
+                    Get in Touch
+                  </a>
+                </div>
+              </div>
             </div>
-        </main>
-    </NuxtLayout>
+          </div>
+        </section>
+      </div>
+    </main>
+  </NuxtLayout>
 </template>
 
-<script setup> 
-  const layout = "default";
+<script setup>
+const layout = "default";
 </script>

--- a/pages/events.vue
+++ b/pages/events.vue
@@ -4,9 +4,9 @@
      <!--
                     This page needs to read content dynamically from a component
      -->
-        <main>
+     <main class="bg-white md:bg-white/90 dark:bg-slate-900 dark:md:bg-slate-900 border-b dark:border-b-0">
             <div class="text-center pb-10 md:pb-16 max-w-4xl mx-auto">
-                <h1 class="text-5xl md:text-6xl font-bold leading-tighter tracking-tighter mb-6 font-heading">         
+                <h1 class="text-5xl md:text-6xl dark:text-white font-bold leading-tighter tracking-tighter mb-6 font-heading">         
                 Events
                 </h1> 
                 <section>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,5 +16,10 @@ module.exports = {
       },
     },
   },
-darkMode: "class",
+  plugins: [
+    require('@tailwindcss/typography'),
+    // ...
+  ],
+//darkMode: "class",
+darkMode: ['class', '[data-mode="dark"]'],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const colors = require("tailwindcss/colors")
 
 module.exports = {
   content: [
-    './src/**/*.{js,ts,jsx,tsx,md,mdx}',
+    './src/**/*.{html,js,ts,jsx,tsx,md,mdx,vue}',
   ],
   theme: {
     extend: {
@@ -20,6 +20,6 @@ module.exports = {
     require('@tailwindcss/typography'),
     // ...
   ],
-//darkMode: "class",
-darkMode: ['class', '[data-mode="dark"]'],
+darkMode: 'class',
+//darkMode: ['class', '[data-mode="dark"]'],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -809,6 +809,16 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
+"@tailwindcss/typography@^0.5.8":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.8.tgz#8fb31db5ab0590be6dfa062b1535ac86ad9d12bf"
+  integrity sha512-xGQEp8KXN8Sd8m6R4xYmwxghmswrd0cPnNI2Lc6fmrC3OojysTBJJGSIVwPV56q4t6THFUK3HJ0EaWwpglSxWw==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -3744,6 +3754,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -3778,6 +3793,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.pick@^4.4.0:
   version "4.4.0"
@@ -5309,6 +5329,14 @@ postcss-reduce-transforms@^5.1.0:
   integrity sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==
   dependencies:
     postcss-value-parser "^4.2.0"
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5, postcss-selector-parser@^6.0.9:
   version "6.0.11"


### PR DESCRIPTION
fix dark/light color mode rendering (was broken before), don't use in page style override
fix markdown color rendering (now works for both light/dark mode, added typography plugin)
fix default template for dark/light background

Todo: eliminate flash on page change. 

